### PR TITLE
Add cert-tools to the requirements.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ RUN mkdir /code
 WORKDIR /code
 ADD requirements.txt /code/
 RUN pip install -r requirements.txt
-#RUN pip install -e git+https://github.com/blockchain-certificates/cert-tools#egg=cert-tools
 ADD . /code/
 WORKDIR /code
 CMD ["sh", "run.sh"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ django>=2.1.3
 psycopg2-binary>=2.7.5
 python-dotenv>=0.9.1
 cert-mailer
+-e git+https://github.com/blockchain-certificates/cert-tools@master#egg=cert_tools
 django-bootstrap4>=0.0.8
 django-bootstrap-datepicker-plus>=3.0.5
 django-cas-ng>=3.6.0

--- a/run.sh
+++ b/run.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 #python3 /code/manage.py flush --noinput
-pip install -e git+https://github.com/blockchain-certificates/cert-tools#egg=cert-tools
 python3 /code/manage.py makemigrations
 python3 /code/manage.py migrate --noinput
 python3 /code/import_data.py


### PR DESCRIPTION
Point to their master branch since pypi version is stale.

Remove package sideloading.