### PR TITLE
save unsigned certs as json

### DIFF
--- a/issuer/admin.py
+++ b/issuer/admin.py
@@ -1,5 +1,5 @@
 from django.contrib import admin
-from .models import Person, Credential, Issuance, CertMailerConfig
+from .models import Person, Credential, Issuance, CertMailerConfig, PersonIssuances
 
 # Register your models here.
 
@@ -8,3 +8,4 @@ admin.site.register(Person)
 admin.site.register(Credential)
 admin.site.register(Issuance)
 admin.site.register(CertMailerConfig)
+admin.site.register(PersonIssuances)

--- a/issuer/models.py
+++ b/issuer/models.py
@@ -73,3 +73,6 @@ class PersonIssuances(models.Model):
     issuance = models.ForeignKey(Issuance, on_delete=models.CASCADE)
     is_issued = models.BooleanField(default=False)
     unsigned_certificate = models.TextField(default='')
+
+    def __str__(self):
+        return f'{self.person}: {self.issuance}'

--- a/issuer/views.py
+++ b/issuer/views.py
@@ -185,10 +185,10 @@ class UnsignedCertificatesView(View):
                           'identity': person.email}
                 person = Recipient(person)
 
-                person_issuance.unsigned_certificate = create_unsigned_certificates_from_roster(json.loads(issuance.certificate_template),
-                                                                                                [person], False,
-                                                                                                cert_tools_config.additional_per_recipient_fields,
-                                                                                                cert_tools_config.hash_emails)
+                person_issuance.unsigned_certificate = json.dumps(create_unsigned_certificates_from_roster(json.loads(issuance.certificate_template),
+                                                                                                           [person], False,
+                                                                                                           cert_tools_config.additional_per_recipient_fields,
+                                                                                                           cert_tools_config.hash_emails))
                 person_issuance.save()
                 print("Save")
         return HttpResponse("DONE")


### PR DESCRIPTION
This will help us do issuances until cert-issuer is integrated.