### PR TITLE
allow aws healthchecks

### DIFF
--- a/admin_app/settings.py
+++ b/admin_app/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/1.10/ref/settings/
 
 import os
 import sentry_sdk
+import requests
 from dotenv import load_dotenv
 from sentry_sdk.integrations.django import DjangoIntegration
 
@@ -168,3 +169,13 @@ SENTRY_DSN = os.getenv('SENTRY_DSN')
 sentry_sdk.init(
         dsn=SENTRY_DSN, integrations=[DjangoIntegration()]
 )
+
+# AWS Healthchecks
+EC2_PRIVATE_IP = None
+try:
+    EC2_PRIVATE_IP = requests.get('http://169.254.169.254/latest/meta-data/local-ipv4', timeout=0.01).text
+except requests.exceptions.RequestException:
+    pass
+
+if EC2_PRIVATE_IP:
+    ALLOWED_HOSTS.append(EC2_PRIVATE_IP)


### PR DESCRIPTION
The healthchecks from the aws elb set the host header to the local ip, since that's not in ALLOWED_HOSTS we get an error that goes to sentry, this happens so frequently that it's exhausted the free tier allowances there over just a few days.