### PR TITLE
Separate buildspec concerns.

### DIFF
--- a/buildspec.deploy.yml
+++ b/buildspec.deploy.yml
@@ -29,9 +29,6 @@ phases:
 
       # Pull this image for the build to cache from.
       - docker pull $REPO_URL:$TAG || true
-      
-      # docker-compose to run e2e tests
-      - docker-compose --no-ansi -f ./e2e/docker-compose.test.yml up --exit-code-from e2e
   build:
     commands:
       - echo Cache from $REPO_URL:$TAG

--- a/buildspec.test.yml
+++ b/buildspec.test.yml
@@ -1,0 +1,10 @@
+version: 0.2
+
+phases:
+  install:
+    runtime-versions:
+      docker: 18
+  build:
+    commands:
+      # docker-compose to run e2e tests
+      - docker-compose --no-ansi -f ./e2e/docker-compose.test.yml up --exit-code-from e2e


### PR DESCRIPTION
Refactor into two buildspec files, one that only runs tests, and one that builds/deploys the container.