### PR TITLE
change to using ThreadPoolExecutor

### DIFF
--- a/issuer/views.py
+++ b/issuer/views.py
@@ -83,7 +83,7 @@ def send_invite(person, credential, is_reminder=False):
 
 def send_invites(people, credential, is_reminder=False):
     if len(people) > 0:
-        with concurrent.futures.ProcessPoolExecutor(max_workers=10) as executor:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
             executor.map(send_invite, people, repeat(credential), repeat(is_reminder))
 
 


### PR DESCRIPTION
For some reason only 1 message is being sent from aws when using send_invites(), I suspect there's an issue with the ProcessPoolExecuter and our number of provisioned cpus on the ecs instance. ThreadPoolExecutor will just use python threads in the existing process.